### PR TITLE
Use a patch for the revised Shiboken2Config.cmake

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-python-qt-binding
 	pkgdesc = ROS - This stack provides Python bindings for Qt.
 	pkgver = 0.3.6
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/python_qt_binding
 	arch = any
 	license = BSD
@@ -13,7 +13,9 @@ pkgbase = ros-melodic-python-qt-binding
 	makedepends = qt5-base
 	depends = python-pyqt5
 	source = ros-melodic-python-qt-binding-0.3.6.tar.gz::https://github.com/ros-visualization/python_qt_binding/archive/0.3.6.tar.gz
+	source = 69-shiboken-cmake.patch::https://github.com/ros-visualization/python_qt_binding/commit/274b1c775daa97ac040d01779d7bd89f5d4ee771.diff
 	sha256sums = b56b8b35f72b8543aab7903eb4e9d456991994a06032a08ba72ba627c6652e12
+	sha256sums = 0aff7f07a1cdb9b09bbf792c4d79e431c8f4a5ccdd2d5a34168dd0a81ad4beb7
 
 pkgname = ros-melodic-python-qt-binding
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/python_qt_binding'
 pkgname='ros-melodic-python-qt-binding'
 pkgver='0.3.6'
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(
@@ -31,8 +31,15 @@ depends=(
 )
 
 _dir="python_qt_binding-${pkgver}"
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-visualization/python_qt_binding/archive/${pkgver}.tar.gz")
-sha256sums=('b56b8b35f72b8543aab7903eb4e9d456991994a06032a08ba72ba627c6652e12')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-visualization/python_qt_binding/archive/${pkgver}.tar.gz"
+        "69-shiboken-cmake.patch"::"https://github.com/ros-visualization/python_qt_binding/commit/274b1c775daa97ac040d01779d7bd89f5d4ee771.diff")
+sha256sums=('b56b8b35f72b8543aab7903eb4e9d456991994a06032a08ba72ba627c6652e12'
+            '0aff7f07a1cdb9b09bbf792c4d79e431c8f4a5ccdd2d5a34168dd0a81ad4beb7')
+
+prepare() {
+	cd ${srcdir}/${_dir}
+	patch -p1 < "../69-shiboken-cmake.patch"
+}
 
 build() {
 	# Use ROS environment variables.


### PR DESCRIPTION
Shiboken has made an incompatible change to its CMake files that requires an upstream change and breaks builds with new shiboken versions. This is not yet released upstream. This change manually applies the merged patch and can be discarded for the next upstream release.

See [the upstream issue](https://github.com/ros-visualization/python_qt_binding/issues/69) for details.